### PR TITLE
Rustintro 2 persistant data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+data.persist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,7 @@ checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
 dependencies = [
  "async-trait",
  "axum-core",
+ "axum-macros",
  "bytes",
  "futures-util",
  "http",
@@ -123,6 +124,18 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00c055ee2d014ae5981ce1016374e8213682aa14d9bf40e48ab48b5f3ef20eaa"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -322,6 +335,12 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -636,7 +655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb182580f71dd070f88d01ce3de9f4da5021db7115d2e1c3605a754153b77c1"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.5.0",
  "itertools",
  "log",
  "multimap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 tokio = { version = "1.26.0", features = ["full"] }
-axum = "0.7.4"
+axum = { version = "0.7.4", features = ["macros"] }
 aide = { version = "0.13.1", features = ["axum"] }
 prost = "0.13.1"
 prost-types = "0.13.1"

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,0 +1,66 @@
+use std::{
+    fs,
+    io::{Cursor, Read, Write}
+};
+use rust_intro::rust_intro::DataMessage;
+use prost::Message;
+
+const FILE: &str = "data.persist";
+
+#[derive(Clone)]
+pub(super) struct DataHandler {
+    data: Vec<DataMessage>,
+}
+
+impl DataHandler {
+    fn deserialize_multiple(buf: &[u8]) -> Vec<DataMessage> {
+        let mut cursor = Cursor::new(buf);
+
+        let mut messages = Vec::new();
+
+        while cursor.position() < buf.len() as u64 {
+            // can decode data which has been encoded by encode_length_delimited!
+            // this is the easiest way to decode multiple messages, as a regular decode would consume the buffer
+            let msg = DataMessage::decode_length_delimited(&mut cursor).expect("could not decode protobuf!");
+            messages.push(msg);
+        }
+
+        messages
+    }
+
+    pub fn new() -> Self {
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .read(true)
+            .create(true)
+            .truncate(false)
+            .open(FILE)
+            .expect("could not open file");
+
+        let mut content = vec![];
+
+        file.read_to_end(&mut content).expect("could not read from file");
+
+        let current_data = Self::deserialize_multiple(content.as_slice());
+
+        Self { data: current_data }
+    }
+
+    pub fn add(&mut self, data: DataMessage) {
+        // prevent duplicates
+        if self.data.iter().any(|x| x.id == data.id) {
+            return;
+        }
+
+        let mut file = fs::OpenOptions::new().append(true).open(FILE).expect("could not open file");
+
+        // encode the data length delimited to allow length delimited decoding
+        file.write_all(data.encode_length_delimited_to_vec().as_slice()).expect("could not write to file");
+
+        self.data.push(data);
+    }
+
+    pub fn get(&self, id: &String) -> Option<DataMessage> {
+        Some(self.data.iter().find(|x| x.id == *id)?.clone())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,7 @@
+extern crate core;
+
 mod routing;
+mod data;
 
 const PORT: u16 = 4200;
 
@@ -9,7 +12,7 @@ async fn main() {
     loop {
         let routes;
         {
-            routes = routing::init_routes();
+            routes = routing::init_routes().await;
         }
         println!("Starting server on port: {}", PORT);
         let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", PORT)).await.unwrap();

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -1,30 +1,58 @@
-use axum::extract::Path;
-use axum::Router;
-use axum::routing::get;
+use std::sync::{Arc, RwLock};
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    routing::{get, post},
+    response::Response,
+    Router
+};
 use rust_intro::rust_intro::DataMessage;
+use crate::data::DataHandler;
 
-pub(crate) fn init_routes() -> Router {
+pub(crate) async fn init_routes() -> Router {
+    let handler = Arc::new(RwLock::new(DataHandler::new()));
     Router::new()
         .route("/", get(route_root))
         .route("/test", get(route_test))
         .route("/test/:path_param", get(route_test_with_param))
         .route("/proto/serialize/:path_param", get(route_serialize_testparam))
+        .route("/proto/:data_message_id/:message", post(route_add_data_msg))
+        .route("/proto/:data_message_id", get(route_get_data_msg))
+        .with_state(handler)
 }
 
-async fn route_root() -> &'static str {
+async fn route_root(_: State<Arc<RwLock<DataHandler>>>) -> &'static str {
     "Welcome to rust-intro"
 }
 
-async fn route_test() -> &'static str {
+async fn route_test(_: State<Arc<RwLock<DataHandler>>>) -> &'static str {
     "Test route"
 }
 
-async fn route_test_with_param(Path(path_param): Path<String>) -> String {
+async fn route_test_with_param(_: State<Arc<RwLock<DataHandler>>>, Path(path_param): Path<String>) -> String {
     format!("Test route with param: {}", path_param)
 }
 
-async fn route_serialize_testparam(Path(testparam): Path<String>) -> String {
-    let data = DataMessage {id: String::from("1"), content: testparam};
+async fn route_serialize_testparam(_: State<Arc<RwLock<DataHandler>>>, Path(testparam): Path<String>) -> String {
+    let data = DataMessage { id: String::from("1"), content: testparam };
 
     format!("{:?}", data)
+}
+
+async fn route_add_data_msg(State(state): State<Arc<RwLock<DataHandler>>>, Path((id, content)): Path<(String, String)>) -> StatusCode {
+    let mut lock = state.write().expect("could not get write lock");
+
+    lock.add(DataMessage { id, content });
+
+    StatusCode::OK
+}
+
+async fn route_get_data_msg(State(state): State<Arc<RwLock<DataHandler>>>, Path(id): Path<String>) -> Response<String> {
+    let lock = state.read().expect("could not get read lock");
+
+    if let Some(msg) = lock.get(&id) {
+        Response::builder().status(StatusCode::OK).body(format!("{:?}", msg)).expect("could not create http response")
+    } else {
+        Response::builder().status(StatusCode::NOT_FOUND).body(format!("no message found with id {:?}", id)).expect("could not create http response")
+    }
 }


### PR DESCRIPTION
Adds 2 routes for creating and retreiving persistant data

The data is stored as length encoded protobuffer and read again on startup.

I could not quite remember the details of the user story so I implemented the following behaviour
- IDs are unique, it is not possible to add multiple messages with the same id
- Currently there is no way to update the content of a message, but this could be easily done, as the check for ids already exists...

Another issue i found was that adding a message with id "serialize" is not possible since there already exists a route with /proto/serialize/ from the first user story